### PR TITLE
content: AI Practice positioning — About, Projects, /speaking, Bluesky

### DIFF
--- a/app/speaking/page.tsx
+++ b/app/speaking/page.tsx
@@ -1,0 +1,89 @@
+import Link from '@/components/Link'
+import { genPageMetadata } from 'app/seo'
+
+export const metadata = genPageMetadata({ title: 'Speaking' })
+
+interface Talk {
+  title: string
+  venue: string
+  year: string
+  href: string
+  description: string
+}
+
+const talks: Talk[] = [
+  {
+    title: 'Go the Distance with Inspire Scaler',
+    venue: "Inspire Days (Quadient's user conference)",
+    year: '2021',
+    href: 'https://www.quadient.com/resources/go-distance-inspire-scaler',
+    description:
+      'Follow-up session on operating Inspire Scaler at scale — what production lessons looked like a year in.',
+  },
+  {
+    title: "Inspire Scaler — What's in it for me?",
+    venue: "Inspire Days (Quadient's virtual user conference)",
+    year: '2020',
+    href: 'https://www.quadient.com/resources/inspire-scaler-whats-it-me',
+    description:
+      'Introduction to Inspire Scaler for the existing Inspire customer base — positioning, capabilities, and adoption path.',
+  },
+  {
+    title: 'FinovateFall 2017 — main-stage demo',
+    venue: 'FinovateFall, New York City',
+    year: '2017',
+    href: '/blog/finovate-2017',
+    description:
+      'Seven-minute live demo on the Finovate main stage representing Quadient. The format is unforgiving — when the bell rings, the mic cuts.',
+  },
+]
+
+export default function Speaking() {
+  return (
+    <>
+      <div className="divide-y divide-gray-200 dark:divide-gray-700">
+        <div className="space-y-2 pt-6 pb-8 md:space-y-5">
+          <h1 className="text-3xl leading-9 font-extrabold tracking-tight text-gray-900 sm:text-4xl sm:leading-10 md:text-6xl md:leading-14 dark:text-gray-100">
+            Speaking
+          </h1>
+          <p className="text-lg leading-7 text-gray-500 dark:text-gray-400">
+            Past talks below. I'm interested in doing more — conference sessions, podcast
+            appearances, internal tech talks. If something here resonates, find me on{' '}
+            <Link
+              href="https://www.linkedin.com/in/robert-w-tucker"
+              className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+            >
+              LinkedIn
+            </Link>
+            .
+          </p>
+        </div>
+        <div className="container py-12">
+          <ul className="space-y-10">
+            {talks.map((talk) => (
+              <li key={talk.title} className="space-y-2">
+                <div className="flex flex-wrap items-baseline gap-x-3">
+                  <span className="text-sm font-medium text-gray-500 dark:text-gray-400">
+                    {talk.year}
+                  </span>
+                  <h2 className="text-2xl leading-8 font-bold tracking-tight">
+                    <Link
+                      href={talk.href}
+                      className="hover:text-primary-500 dark:hover:text-primary-400 text-gray-900 dark:text-gray-100"
+                    >
+                      {talk.title}
+                    </Link>
+                  </h2>
+                </div>
+                <p className="text-sm text-gray-500 dark:text-gray-400">{talk.venue}</p>
+                <p className="prose max-w-none text-gray-500 dark:text-gray-400">
+                  {talk.description}
+                </p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/data/authors/default.mdx
+++ b/data/authors/default.mdx
@@ -4,6 +4,7 @@ avatar: /static/images/avatar.jpg
 occupation: Principal Solution Architect
 company: Quadient
 twitter: https://twitter.com/robertwtucker
+bluesky: https://bsky.app/profile/robertwtucker.com
 linkedin: https://www.linkedin.com/in/robert-w-tucker
 github: https://github.com/robertwtucker
 ---

--- a/data/authors/default.mdx
+++ b/data/authors/default.mdx
@@ -10,12 +10,26 @@ github: https://github.com/robertwtucker
 
 #
 
-Robert Tucker is a software professional currently working as a Principal
-Solution Architect with [Quadient](https://quadient.com). Since 2006, has held
-a variety of roles in the Customer Experience Management industry including
-stints in Product Management, R&D and Pre-Sales. Prior to that, he spent over a
-decade in Professional Services (consulting) with Microsoft and a regional
-solution provider.
+Robert Tucker is a senior technical generalist — a developer, integrator, and
+solution architect with three decades of receipts. He's currently a [Principal
+Solution Architect at Quadient](https://quadient.com), where he focuses on
+integration accelerator design, container/Kubernetes deployment, and now
+AI-native tooling for the customer-experience domain.
+
+Earlier chapters: developer at Pennzoil (1993), Microsoft-stack consultant and
+Practice Manager at Software Spectrum, Managing Consultant at Microsoft
+Consulting Services, software designer at HP Exstream, and Solutions Product
+Manager at HP — where he designed integration accelerators for SAP, Guidewire,
+and Duck Creek. Twenty years in the customer-communications industry; fourteen
+years of integration-accelerator work as a paid craft.
+
+Outside of Quadient he runs [Eclectic Development LLC](https://eclectic.dev),
+ships [KFinder](https://kfinderapp.com) (a published,
+[open-source](https://github.com/robertwtucker/kfinderapp-ios) iOS app for
+warfarin/INR tracking), and is currently writing in public about AI-native
+development for the underserved technical middle — solutions architects,
+integration consultants, technical PMs, the people who code competently but
+were velocity-bottlenecked until the models got good.
 
 ## The terms
 

--- a/data/authors/default.mdx
+++ b/data/authors/default.mdx
@@ -14,15 +14,16 @@ github: https://github.com/robertwtucker
 Robert Tucker is a senior technical generalist — a developer, integrator, and
 solution architect with three decades of receipts. He's currently a [Principal
 Solution Architect at Quadient](https://quadient.com), where he focuses on
-integration accelerator design, container/Kubernetes deployment, and now
+integration accelerator design, container deployment/orchestration, and now
 AI-native tooling for the customer-experience domain.
 
-Earlier chapters: developer at Pennzoil (1993), Microsoft-stack consultant and
+Earlier chapters: developer at Pennzoil, Microsoft-stack consultant and
 Practice Manager at Software Spectrum, Managing Consultant at Microsoft
-Consulting Services, software designer at HP Exstream, and Solutions Product
-Manager at HP — where he designed integration accelerators for SAP, Guidewire,
-and Duck Creek. Twenty years in the customer-communications industry; fourteen
-years of integration-accelerator work as a paid craft.
+Consulting Services, several years at HP Exstream (now OpenText Exstream) —
+Technical Product Manager, Software Designer, and Solutions Product Manager —
+where he designed integration accelerators for SAP, Guidewire, and Duck Creek.
+Twenty years in customer-communications; seventeen years of integration-
+accelerator work as a paid craft.
 
 Outside of Quadient he runs [Eclectic Development LLC](https://eclectic.dev),
 ships [KFinder](https://kfinderapp.com) (a published,
@@ -46,8 +47,8 @@ injuries, or damages from the display or use of this information.
 
 In case you were wondering, this site is:
 
-- Coded with [Visual Studio Code](https://code.visualstudio.com) in vim-mode on
-  a Mac.
+- Coded with [NeoVim](https://neovim.io/) ([LazyVim](https://www.lazyvim.org/)
+  setup on a Mac.
 - Built using [Next.js](https://nextjs.org).
 - Hosted on [Vercel](https://vercel.com/home).
 - [Open source](https://github.com/robertwtucker/robertwtucker-site) and made

--- a/data/headerNavLinks.ts
+++ b/data/headerNavLinks.ts
@@ -3,6 +3,7 @@ const headerNavLinks = [
   { href: '/blog', title: 'Blog' },
   { href: '/tags', title: 'Tags' },
   { href: '/projects', title: 'Projects' },
+  { href: '/speaking', title: 'Speaking' },
   { href: '/about', title: 'About' },
 ]
 

--- a/data/projectsData.ts
+++ b/data/projectsData.ts
@@ -8,16 +8,25 @@ interface Project {
 const projectsData: Project[] = [
   {
     title: 'KFinder for iOS',
-    description: `My 'perpetual side-project' is now available on the App Store!`,
+    description: `A published iOS app for warfarin/INR tracking — vitamin K content,
+    historical readings, and dose context for patients on anticoagulant therapy.
+    Open source under the MIT License; available on the App Store.`,
     imgSrc: '/static/images/iphone.jpg',
     href: 'https://kfinderapp.com',
   },
   {
-    title: 'Cheat Sheet for Dash',
-    description: `I created a cheat sheet for Oh-My-Zsh's kubectl plugin. If you
-    code on a Mac, you should check out Dash!`,
-    imgSrc: '/static/images/devops.jpg',
-    href: 'https://kapeli.com/cheat_sheets/Oh-My-Zsh_Kubectl.docset/Contents/Resources/Documents/index',
+    title: 'PARA Vault MCP',
+    description: `An open-source Model Context Protocol server that exposes a PARA-method
+    Obsidian vault as structured tools for MCP-capable AI clients. The first proof
+    artifact of an in-public AI practice. Building toward v0.1.`,
+    href: 'https://github.com/robertwtucker/para-vault-mcp',
+  },
+  {
+    title: 'Eclectic Development LLC',
+    description: `The workshop. Independent software outfit — home for side projects,
+    open-source releases, and (eventually) consulting work. Distinct face from
+    this personal site.`,
+    href: 'https://eclectic.dev',
   },
 ]
 

--- a/data/siteMetadata.js
+++ b/data/siteMetadata.js
@@ -13,6 +13,7 @@ const siteMetadata = {
   // mastodon: 'https://mastodon.social/@robertwtucker',
   github: 'https://github.com/robertwtucker',
   x: 'https://x.com/robertwtucker',
+  bluesky: 'https://bsky.app/profile/robertwtucker.com',
   linkedin: 'https://www.linkedin.com/in/robert-w-tucker',
   locale: 'en-US',
   // set to true if you want a navbar fixed to the top


### PR DESCRIPTION
## Summary
Phase 1 of the AI Practice positioning pass — light content edits only; full redesign tracked separately.

- **About**: rewrote bio to foreground the 30-year arc (Pennzoil → MS/MCS → HP Exstream → HP integration accelerators → Quadient), Eclectic Development LLC, KFinder, and the in-public AI-native pivot. Title aligned to current Workday role (Principal Solution Architect).
- **Projects**: KFinder reframed as flagship (App Store + open-source repo + MIT); added PARA Vault MCP (build-in-public proof artifact) and Eclectic Development LLC (the workshop face); dropped Cheat Sheet for Dash.
- **/speaking**: new page covering FinovateFall 2017, Inspire Days 2020 and 2021 — framed as availability rather than résumé. Added to header nav.
- **Bluesky**: wired up `@robertwtucker.com` in `siteMetadata.js` and the default author frontmatter. Footer and AuthorLayout already render the icon when the field is present — no component changes needed.

## Test plan
- [x] `pnpm dev` — verify /about, /projects, /speaking render
- [x] Confirm Bluesky icon appears in footer and About page social row
- [x] Confirm /speaking link appears in header nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)