### PR TITLE
fix: update Umami script URL to cloud.umami.is

### DIFF
--- a/data/siteMetadata.js
+++ b/data/siteMetadata.js
@@ -26,8 +26,8 @@ const siteMetadata = {
       // We use an env variable for this site to avoid other users cloning our analytics ID
       umamiWebsiteId: process.env.NEXT_UMAMI_ID, // e.g. 123e4567-e89b-12d3-a456-426614174000
       // You may also need to overwrite the script if you're storing data in the US - ex:
-      src: 'https://us.umami.is/script.js',
-      // Remember to add 'us.umami.is' in `next.config.js` as a permitted domain for the CSP
+      src: 'https://cloud.umami.is/script.js',
+      // Remember to add 'cloud.umami.is' in `next.config.js` as a permitted domain for the CSP
     },
     // plausibleAnalytics: {
     //   plausibleDataDomain: '', // e.g. tailwind-nextjs-starter-blog.vercel.app

--- a/next.config.js
+++ b/next.config.js
@@ -7,7 +7,7 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 // You might need to insert additional domains in script-src if you are using external services
 const ContentSecurityPolicy = `
   default-src 'self';
-  script-src 'self' 'unsafe-eval' 'unsafe-inline' giscus.app us.umami.is;
+  script-src 'self' 'unsafe-eval' 'unsafe-inline' giscus.app cloud.umami.is;
   style-src 'self' 'unsafe-inline';
   img-src * blob: data:;
   media-src *.s3.amazonaws.com;


### PR DESCRIPTION
## Summary
- Umami migrated their cloud script host from `us.umami.is` to `cloud.umami.is`, silencing analytics starting 2026-05-09
- Updates `data/siteMetadata.js` script src and matching comment
- Updates `next.config.js` CSP `script-src` allowlist to the new domain
- Website ID unchanged — historical data continues uninterrupted

## Test plan
- [x] Vercel preview deploys cleanly
- [x] View source on preview URL shows `<script ... src="https://cloud.umami.is/script.js" data-website-id="28c326a9-…">`
- [ ] DevTools Network tab on preview navigation shows a 200 to `cloud.umami.is` (script load) and a 200 to `cloud.umami.is/api/send` (beacon)
- [ ] No CSP violations in browser console
- [ ] After merge, confirm new events land in the Umami dashboard within a few minutes of the production deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)