### PR TITLE
feat: hero + featured post (PR 3 of redesign)

### DIFF
--- a/app/Main.tsx
+++ b/app/Main.tsx
@@ -3,72 +3,80 @@ import Tag from '@/components/Tag'
 import siteMetadata from '@/data/siteMetadata'
 import { formatDate } from 'pliny/utils/formatDate'
 import NewsletterForm from 'pliny/ui/NewsletterForm'
+import Hero from '@/components/Hero'
+import FeaturedPost from '@/components/FeaturedPost'
 
 const MAX_DISPLAY = 5
+const HERO_TAGLINE =
+  'Twenty years building customer-communications integration. Writing in public about AI-native work for the technical middle.'
 
 export default function Home({ posts }) {
+  const featured = posts[0]
+  const rest = posts.slice(1, MAX_DISPLAY)
+
   return (
     <>
       <div className="divide-y divide-gray-200 dark:divide-gray-700">
-        <div className="space-y-2 pt-6 pb-8 md:space-y-5">
-          <h1 className="text-3xl leading-9 font-extrabold tracking-tight text-gray-900 sm:text-4xl sm:leading-10 md:text-6xl md:leading-14 dark:text-gray-100">
-            Latest
-          </h1>
-          <p className="text-lg leading-7 text-gray-500 dark:text-gray-400">
-            {siteMetadata.description}
-          </p>
-        </div>
-        <ul className="divide-y divide-gray-200 dark:divide-gray-700">
-          {!posts.length && 'No posts found.'}
-          {posts.slice(0, MAX_DISPLAY).map((post) => {
-            const { slug, date, title, summary, tags } = post
-            return (
-              <li key={slug} className="py-12">
-                <article>
-                  <div className="space-y-2 xl:grid xl:grid-cols-4 xl:items-baseline xl:space-y-0">
-                    <dl>
-                      <dt className="sr-only">Published on</dt>
-                      <dd className="text-base leading-6 font-medium text-gray-500 dark:text-gray-400">
-                        <time dateTime={date}>{formatDate(date, siteMetadata.locale)}</time>
-                      </dd>
-                    </dl>
-                    <div className="space-y-5 xl:col-span-3">
-                      <div className="space-y-6">
-                        <div>
-                          <h2 className="text-2xl leading-8 font-bold tracking-tight">
-                            <Link
-                              href={`/blog/${slug}`}
-                              className="text-gray-900 dark:text-gray-100"
-                            >
-                              {title}
-                            </Link>
-                          </h2>
-                          <div className="flex flex-wrap">
-                            {tags.map((tag) => (
-                              <Tag key={tag} text={tag} />
-                            ))}
+        <Hero name={siteMetadata.author} tagline={HERO_TAGLINE} />
+        {!posts.length ? (
+          <div className="text-muted-foreground py-12">No posts found.</div>
+        ) : (
+          <>
+            <FeaturedPost post={featured} />
+            {rest.length > 0 && (
+              <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+                {rest.map((post) => {
+                  const { slug, date, title, summary, tags } = post
+                  return (
+                    <li key={slug} className="py-12">
+                      <article>
+                        <div className="space-y-2 xl:grid xl:grid-cols-4 xl:items-baseline xl:space-y-0">
+                          <dl>
+                            <dt className="sr-only">Published on</dt>
+                            <dd className="text-base leading-6 font-medium text-gray-500 dark:text-gray-400">
+                              <time dateTime={date}>{formatDate(date, siteMetadata.locale)}</time>
+                            </dd>
+                          </dl>
+                          <div className="space-y-5 xl:col-span-3">
+                            <div className="space-y-6">
+                              <div>
+                                <h2 className="text-2xl leading-8 font-bold tracking-tight">
+                                  <Link
+                                    href={`/blog/${slug}`}
+                                    className="text-gray-900 dark:text-gray-100"
+                                  >
+                                    {title}
+                                  </Link>
+                                </h2>
+                                <div className="flex flex-wrap">
+                                  {tags.map((tag) => (
+                                    <Tag key={tag} text={tag} />
+                                  ))}
+                                </div>
+                              </div>
+                              <div className="prose max-w-none text-gray-500 dark:text-gray-400">
+                                {summary}
+                              </div>
+                            </div>
+                            <div className="text-base leading-6 font-medium">
+                              <Link
+                                href={`/blog/${slug}`}
+                                className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+                                aria-label={`Read more: "${title}"`}
+                              >
+                                Read more &rarr;
+                              </Link>
+                            </div>
                           </div>
                         </div>
-                        <div className="prose max-w-none text-gray-500 dark:text-gray-400">
-                          {summary}
-                        </div>
-                      </div>
-                      <div className="text-base leading-6 font-medium">
-                        <Link
-                          href={`/blog/${slug}`}
-                          className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
-                          aria-label={`Read more: "${title}"`}
-                        >
-                          Read more &rarr;
-                        </Link>
-                      </div>
-                    </div>
-                  </div>
-                </article>
-              </li>
-            )
-          })}
-        </ul>
+                      </article>
+                    </li>
+                  )
+                })}
+              </ul>
+            )}
+          </>
+        )}
       </div>
       {posts.length > MAX_DISPLAY && (
         <div className="flex justify-end text-base leading-6 font-medium">

--- a/components/FeaturedPost.tsx
+++ b/components/FeaturedPost.tsx
@@ -1,0 +1,43 @@
+import Link from '@/components/Link'
+import Tag from '@/components/Tag'
+import siteMetadata from '@/data/siteMetadata'
+import { formatDate } from 'pliny/utils/formatDate'
+import type { CoreContent } from 'pliny/utils/contentlayer'
+import type { Blog } from 'contentlayer/generated'
+
+type FeaturedPostProps = {
+  post: CoreContent<Blog>
+}
+
+export default function FeaturedPost({ post }: FeaturedPostProps) {
+  const { slug, date, title, summary, tags } = post
+
+  return (
+    <article className="space-y-4 py-8 md:space-y-6 md:py-12">
+      <div className="text-muted-foreground text-xs font-semibold tracking-widest uppercase">
+        Latest
+      </div>
+      <div className="space-y-3">
+        <dl>
+          <dt className="sr-only">Published on</dt>
+          <dd className="text-muted-foreground text-base leading-6 font-medium">
+            <time dateTime={date}>{formatDate(date, siteMetadata.locale)}</time>
+          </dd>
+        </dl>
+        <h2 className="text-2xl leading-8 font-bold tracking-tight md:text-3xl md:leading-9">
+          <Link href={`/blog/${slug}`} className="text-foreground">
+            {title}
+          </Link>
+        </h2>
+        {tags && tags.length > 0 && (
+          <div className="flex flex-wrap">
+            {tags.map((tag) => (
+              <Tag key={tag} text={tag} />
+            ))}
+          </div>
+        )}
+        <p className="text-muted-foreground prose max-w-none">{summary}</p>
+      </div>
+    </article>
+  )
+}

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,0 +1,17 @@
+type HeroProps = {
+  name: string
+  tagline: string
+}
+
+export default function Hero({ name, tagline }: HeroProps) {
+  return (
+    <section className="space-y-4 pt-6 pb-8 md:space-y-6 md:pt-10 md:pb-12">
+      <h1 className="text-foreground text-4xl leading-tight font-extrabold tracking-tight sm:text-5xl md:text-6xl md:leading-none">
+        {name}
+      </h1>
+      <p className="text-muted-foreground max-w-2xl text-lg leading-7 md:text-xl md:leading-8">
+        {tagline}
+      </p>
+    </section>
+  )
+}

--- a/data/siteMetadata.js
+++ b/data/siteMetadata.js
@@ -3,7 +3,7 @@ const siteMetadata = {
   title: 'Eclectic Developer',
   author: 'Robert Tucker',
   headerTitle: 'Robert Tucker',
-  description: 'Ramblings of an eclectic developer',
+  description: 'Notes on AI-native development for the technical middle.',
   language: 'en-us',
   theme: 'system', // system, dark or light
   siteUrl: 'https://robertwtucker.com',


### PR DESCRIPTION
## Summary

- Adds `Hero` component — identity-anchored homepage statement (name + receipts line).
- Adds `FeaturedPost` component — most recent post elevated with visual weight above the uniform list.
- Replaces the existing "Latest" h1 + tagline block in `app/Main.tsx`; the page now has a single semantic h1 (the writer's name).
- Updates `siteMetadata.description` so OG/Twitter/SERP previews align with the new voice.

Spec: `~/vault/1-Projects/robertwtucker.com Redesign/hero-design.md`.
Plan: `~/vault/1-Projects/robertwtucker.com Redesign/hero-implementation.md`.

## Why this shape

Hero is intentionally restrained — no avatar, no accent color, no ornament. Voice register is receipts-forward (twenty years building customer-communications integration; writing in public about AI-native work for the technical middle). Identity anchors first-time visitors without making the homepage a portfolio.

The original PR 3 plan called for four hero variants (Simple/Image/Minimal/Video). Brainstorming narrowed this to a single variant + a separate `FeaturedPost`. The other three are deferred until there's a concrete use case for them — building speculative variants is dead code today.

## Local Lighthouse (desktop, production build)

- Performance: 96
- Accessibility: 96
- Best Practices: 100
- SEO: 100
- LCP 1.4s · CLS 0 · TBT 0 ms

No regression risk from the additions (server components, plain JSX, no client JS).

## Follow-up observation (out of scope for this PR)

The navbar's "Robert Tucker" headerTitle now duplicates the new Hero h1 on the homepage — same identity signal in two places on every page. Worth dropping from the navbar as part of a broader navbar/menu consolidation pass (separate PR). Logged in the project hub.

## Test plan

- [ ] Homepage renders without console errors in production build
- [ ] Exactly one h1 on the page (the writer's name) — verified via DevTools
- [ ] FeaturedPost title links to the post; tags clickable; date renders via `formatDate`
- [ ] Empty-state ("No posts found.") still renders if `posts.length === 0`
- [ ] Mobile (~375px) and desktop (~1280px) breakpoints both look intentional
- [ ] Dark mode renders correctly (toggle via theme switch)
- [ ] Vercel preview reads visually identical to local
- [ ] OG preview shows the new description text (https://www.opengraph.xyz/url/...)
- [ ] RSS feed channel description shows the new description

🤖 Generated with [Claude Code](https://claude.com/claude-code)