### PR TITLE
feat: YouTube MDX component (closes #274)

### DIFF
--- a/components/MDXComponents.tsx
+++ b/components/MDXComponents.tsx
@@ -5,10 +5,12 @@ import type { MDXComponents } from 'mdx/types'
 import Image from './Image'
 import CustomLink from './Link'
 import TableWrapper from './TableWrapper'
+import YouTube from './YouTube'
 
 export const components: MDXComponents = {
   Image,
   TOCInline,
+  YouTube,
   a: CustomLink,
   pre: Pre,
   table: TableWrapper,

--- a/components/YouTube.tsx
+++ b/components/YouTube.tsx
@@ -1,0 +1,19 @@
+type YouTubeProps = {
+  id: string
+  title?: string
+}
+
+const YouTube = ({ id, title }: YouTubeProps) => (
+  <div className="my-6 aspect-video w-full overflow-hidden rounded-lg">
+    <iframe
+      className="h-full w-full"
+      src={`https://www.youtube-nocookie.com/embed/${id}?rel=0`}
+      title={title ?? 'YouTube video player'}
+      loading="lazy"
+      allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+      allowFullScreen
+    />
+  </div>
+)
+
+export default YouTube

--- a/data/blog/finovate-2017.mdx
+++ b/data/blog/finovate-2017.mdx
@@ -27,7 +27,7 @@ While I'm no stranger to presenting in front of an audience, the picture above j
 
 ### The Video
 
-[YouTube](https://youtu.be/PTn_rSZs0ss)
+<YouTube id="PTn_rSZs0ss" title="Quadient at FinovateFall 2017" />
 
 ### Conclusion
 

--- a/next.config.js
+++ b/next.config.js
@@ -13,7 +13,7 @@ const ContentSecurityPolicy = `
   media-src *.s3.amazonaws.com;
   connect-src *;
   font-src 'self';
-  frame-src giscus.app;
+  frame-src giscus.app www.youtube-nocookie.com;
 `
 
 const securityHeaders = [


### PR DESCRIPTION
## Summary

- Adds `components/YouTube.tsx` as a thin wrapper over a raw `<iframe>` to `youtube-nocookie.com` with `loading="lazy"` and a 16:9 aspect ratio
- Registers `<YouTube>` in `MDXComponents.tsx`
- Replaces the temporary `[YouTube](url)` text link in `data/blog/finovate-2017.mdx` with `<YouTube id="PTn_rSZs0ss" title="Quadient at FinovateFall 2017" />`
- Adds `www.youtube-nocookie.com` to `frame-src` in the CSP

Closes #274.

## Design notes

Initial attempt used `@next/third-parties` `YouTubeEmbed`, which provides a thumbnail-preview-before-click via `lite-youtube-embed`. Two reasons we backed off:

1. **CSP friction.** The helper loads its CSS and JS from `cdn.jsdelivr.net`, which the project's CSP correctly blocked (only `'self'`, giscus, umami are allowed). Allowlisting the CDN would have worked.
2. **Unpinned `@master` ref.** The hard-coded asset URL is `cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/...` — no version pin. A breaking change upstream would silently break embeds in production. For a single video on a 2017 post, the supply-chain risk wasn't worth the optimization.

The raw-iframe approach:
- No npm dep (`@next/third-parties` installed then uninstalled; net-zero in lockfile)
- No CDN dependency
- `loading="lazy"` defers the iframe load until scrolled near the viewport
- Privacy-enhanced `youtube-nocookie.com` defers cookie/tracking init until the user clicks play
- `rel=0` limits end-card related videos to the same channel (no cross-channel suggestions)

If we ever start embedding video frequently and the thumbnail-preview-before-click optimization matters, revisit with a self-hosted `lite-youtube-embed` (no CDN, pinned version we control).

## Test plan

- [x] Vercel preview renders the embed on `/blog/finovate-2017` (the video is at the "### The Video" anchor)
- [x] Player loads and plays in light theme
- [x] Player loads and plays in dark theme
- [x] No CSP violations in browser console
- [ ] Page Lighthouse Performance ≥ 95 (lazy-loading should keep LCP unaffected)